### PR TITLE
Add support for configurable CloudWatch logs role description

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ No modules.
 | <a name="input_log_exclude_verbose_content"></a> [log\_exclude\_verbose\_content](#input\_log\_exclude\_verbose\_content) | Set to TRUE to exclude sections that contain information such as headers, context, and evaluated mapping templates, regardless of logging level. | `bool` | `false` | no |
 | <a name="input_log_field_log_level"></a> [log\_field\_log\_level](#input\_log\_field\_log\_level) | Field logging level. Valid values: ALL, ERROR, NONE. | `string` | `null` | no |
 | <a name="input_logging_enabled"></a> [logging\_enabled](#input\_logging\_enabled) | Whether to enable Cloudwatch logging on GraphQL API | `bool` | `false` | no |
+| <a name="input_logs_role_description"></a> [logs\_role\_description](#input\_logs\_role\_description) | Description for the IAM role to create for Cloudwatch logs | `string` | `null` | no |
 | <a name="input_logs_role_name"></a> [logs\_role\_name](#input\_logs\_role\_name) | Name of IAM role to create for Cloudwatch logs | `string` | `null` | no |
 | <a name="input_logs_role_tags"></a> [logs\_role\_tags](#input\_logs\_role\_tags) | Map of tags to add to Cloudwatch logs IAM role | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of GraphQL API | `string` | `""` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -109,6 +109,7 @@ resource "aws_iam_role" "logs" {
   count = var.logging_enabled && var.create_logs_role ? 1 : 0
 
   name                 = coalesce(var.logs_role_name, "${var.name}-logs")
+  description          = var.logs_role_description
   assume_role_policy   = data.aws_iam_policy_document.assume_role.json
   permissions_boundary = var.iam_permissions_boundary
 

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,12 @@ variable "logs_role_name" {
   default     = null
 }
 
+variable "logs_role_description" {
+  description = "Description for the IAM role to create for Cloudwatch logs"
+  type        = string
+  default     = null
+}
+
 variable "log_cloudwatch_logs_role_arn" {
   description = "Amazon Resource Name of the service role that AWS AppSync will assume to publish to Amazon CloudWatch logs in your account."
   type        = string


### PR DESCRIPTION
### Description

This pull request introduces the `logs_role_description` variable to specify a custom description for the IAM role created for CloudWatch logs. This change provides greater flexibility and helps document roles effectively. If not set, the default behavior remains unchanged.
